### PR TITLE
- finishing the previous fix for config import

### DIFF
--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/config/FileGeocoderConfigurationStore.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/config/FileGeocoderConfigurationStore.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ca.bc.gov.ols.config.ConfigurationStore;
 import ca.bc.gov.ols.config.FileConfigurationStore;
 import ca.bc.gov.ols.rowreader.CsvRowReader;
 import ca.bc.gov.ols.rowreader.RowReader;
@@ -170,7 +169,7 @@ public class FileGeocoderConfigurationStore extends FileConfigurationStore imple
 	}
 
 	@Override
-	public void replaceWith(ConfigurationStore configStore) {
+	public void replaceWith(GeocoderConfigurationStore configStore) {
 		super.replaceWith(configStore);
 		if(configStore instanceof GeocoderConfigurationStore) {			
 			writeAbbrevMappings(((GeocoderConfigurationStore)configStore).getAbbrevMappings().collect(Collectors.toList()));			


### PR DESCRIPTION
Sorry in my rush to get you the fix I didn't build it with maven, just my eclipse IDE, where I missed the warning about the compile failure for the file-based config that we aren't using right now.