### PR TITLE
Fix for #251

### DIFF
--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
@@ -183,7 +183,7 @@ public class Geocoder implements IGeocoder {
 			addressWords.addAll(lexer.lexField(query.getUnitNumber(),
 					EnumSet.of(WordClass.NUMBER, WordClass.LETTER)));
 			addressWords.addAll(lexer.lexField(query.getUnitNumberSuffix(),
-					EnumSet.of(WordClass.SUFFIX)));
+					EnumSet.of(WordClass.SUFFIX, WordClass.LETTER)));
 			List<List<MisspellingOf<Word>>> siteWords = lexer.lexField(query.getSiteName(),
 					EnumSet.of(WordClass.NAME));
 			if(siteWords.size() > 0) {
@@ -194,7 +194,7 @@ public class Geocoder implements IGeocoder {
 					query.getCivicNumber() == null ? "" : query.getCivicNumber().toString(),
 					EnumSet.of(WordClass.NUMBER)));
 			addressWords.addAll(lexer.lexField(query.getCivicNumberSuffix(),
-					EnumSet.of(WordClass.SUFFIX)));
+					EnumSet.of(WordClass.SUFFIX, WordClass.LETTER)));
 			addressWords.addAll(lexer.lexField(query.getStreetName(),
 					EnumSet.of(WordClass.STREET_NAME_BODY)));
 			addressWords.addAll(lexer.lexField(query.getStreetType(),


### PR DESCRIPTION
a previous parser change introduced "WordClass.LETTER" which can also be
interpreted as a unit or address suffix, and the appropriate changes
needed to be made in the structured address parsing logic to handle this