### PR TITLE
New links to the Data Services Client Hub

### DIFF
--- a/bc-location-services/batch-geocoder-registration.md
+++ b/bc-location-services/batch-geocoder-registration.md
@@ -6,7 +6,7 @@ If you have a BC IDIR account, you don't need to register to access the Batch Ge
 
 If you don't have a BC IDIR account and are in an agency outside of core goverment (e.g., crown corporation, local or federal government, local health authority, university), here are the steps to registration and access:
 
-1. Request access using the [Data Services Client Hub](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) 
+1. Request access by opening a ticket with the [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) 
  
 2. If you don't have an active bceid account, please register for a basic BCeID account at https://www.bceid.ca/
 

--- a/bc-location-services/batch-geocoder-registration.md
+++ b/bc-location-services/batch-geocoder-registration.md
@@ -6,16 +6,12 @@ If you have a BC IDIR account, you don't need to register to access the Batch Ge
 
 If you don't have a BC IDIR account and are in an agency outside of core goverment (e.g., crown corporation, local or federal government, local health authority, university), here are the steps to registration and access:
 
-1. Provide us (e.g., IDDDBCLS@Victoria1.gov.bc.ca) with answers to the following questions:
-
-     - What is the nature of your business?
-     - How do you propose to use the geocoder?
-     - What business outcomes do you hope the geocoder will help you achieve? 
+1. Request access using the [Data Services Client Hub](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) 
  
 2. If you don't have an active bceid account, please register for a basic BCeID account at https://www.bceid.ca/
 
 3.	Using your bceid account, try to log in to the batch geocoder located at https://apps.gov.bc.ca/pub/cpf/secure/ws/apps/geocoder/
-You will be rejected but don’t take it hard. Just email your bceid account name to us and we will complete the registration process and notify you when your registered. 
+You will be rejected but don’t take it hard. This process registers your account with the system. Once we see your account listed we will grant access to the batch geocoder and send a confirmation email.
 
 Whether you are a BC IDIR user or a BCeID user, you need to learn how to prepare your address list for batch geocoding, submit your list to the batch geocoder, and understand geocoder output. Here are some links to get your started:
 

--- a/faq.md
+++ b/faq.md
@@ -3,7 +3,7 @@
 #### Q: What are the system requirements for using the Geocoder?
 A web browser is required to use the Geocoder web application and Address List Editor.
 To use the Geocoder in Google Earth, Google Earth 6.1 or higher needs to be installed on the user’s computer.
-The Batch Geocoder is not generally available to the public.  To request access please [contact DataBC](https://forms.gov.bc.ca/databc-contact-us/).
+The Batch Geocoder is not generally available to the public.  To request access please [contact DataBC](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15).
 Addresses to be geocoded should be physical addresses and not mailing addresses.
 Postal codes are not supported and will be ignored.
 

--- a/faq.md
+++ b/faq.md
@@ -21,17 +21,17 @@ The Geocoder does not use postal codes to determine address location. Address lo
 
 #### Q: How do I get a Geocoder API key for use in a production BC Government application?
 
-To request a production Geocoder API key [contact DataBC](https://forms.gov.bc.ca/databc-contact-us/) and include a description of the intended usage and consuming application name.
+To request a production Geocoder API key [contact DataBC](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) and include a description of the intended usage and consuming application name.
 
 #### Q: How do I get Geocoder API keys for use by a developer?
 
 There are two steps involved:
 
-Step 1 (one time only): 
-Launch the [API Gateway administration (GWA)](https://gwa.apps.gov.bc.ca/ui/apiKeys) application and login with your GitHub account. This will register you as a developer with the API gateway.
+Step 1: 
+Launch the [API Services Portal](https://api.gov.bc.ca/) application and login with your GitHub account. This will register you as a developer with the API gateway.
 
 Step 2 (per API): 
-To be granted access to create your own developer Geocoder API keys please [contact DataBC](https://forms.gov.bc.ca/databc-contact-us/) and include your GitHub account name as well as confirmation that you have logged into GWA.
+To be granted access to create your own developer Geocoder API keys please [contact DataBC](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) and include your GitHub account name as well as confirmation that you have logged into GWA.
 
 Once you have logged into GWA, and following our team granting access, you should see the BC Address Geocoder listed on the right side of your screen. By expanding each item, you will see the associated rate limit.
 

--- a/faq.md
+++ b/faq.md
@@ -3,7 +3,7 @@
 #### Q: What are the system requirements for using the Geocoder?
 A web browser is required to use the Geocoder web application and Address List Editor.
 To use the Geocoder in Google Earth, Google Earth 6.1 or higher needs to be installed on the user’s computer.
-The Batch Geocoder is not generally available to the public.  To request access please [contact DataBC](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15).
+The Batch Geocoder is not generally available to the public.  To request access please open a ticket with the [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15).
 Addresses to be geocoded should be physical addresses and not mailing addresses.
 Postal codes are not supported and will be ignored.
 
@@ -21,7 +21,7 @@ The Geocoder does not use postal codes to determine address location. Address lo
 
 #### Q: How do I get a Geocoder API key for use in a production BC Government application?
 
-To request a production Geocoder API key [contact DataBC](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) and include a description of the intended usage and consuming application name.
+To request a production Geocoder API key please open a ticket with the [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) and include a description of the intended usage and consuming application name.
 
 #### Q: How do I get Geocoder API keys for use by a developer?
 
@@ -31,7 +31,7 @@ Step 1:
 Launch the [API Services Portal](https://api.gov.bc.ca/) application and login with your GitHub account. This will register you as a developer with the API gateway.
 
 Step 2 (per API): 
-To be granted access to create your own developer Geocoder API keys please [contact DataBC](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) and include your GitHub account name as well as confirmation that you have logged into GWA.
+To be granted access to create your own developer Geocoder API keys please open a ticket with the [Data Systems & Services request system](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/create/15) and include your GitHub account name as well as confirmation that you have logged into GWA.
 
 Once you have logged into GWA, and following our team granting access, you should see the BC Address Geocoder listed on the right side of your screen. By expanding each item, you will see the associated rate limit.
 


### PR DESCRIPTION
Replaced the old contact-us URL with the new Data Services Client Hub link.