### PR TITLE
Changes to StreetPrep and geocoder to support Route Planner 2.2

### DIFF
--- a/ols-geocoder-core/pom.xml
+++ b/ols-geocoder-core/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<ols-util.version>1.3.0-SNAPSHOT</ols-util.version>
+		<ols-util.version>1.3.1-SNAPSHOT</ols-util.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
@@ -18,6 +18,7 @@ package ca.bc.gov.ols.geocoder;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -242,7 +243,7 @@ public class GeocoderDataStore {
 
 	GeometryReprojector reprojector;
 
-	private Map<DateType, LocalDate> dates;
+	private Map<DateType, ZonedDateTime> dates;
 	
 	public GeocoderDataStore(Properties bootstrapConfig, GeometryFactory gf, GeometryReprojector reprojector) {
 		logger.info("GeocoderDataStore() constructor called");
@@ -1968,7 +1969,7 @@ public class GeocoderDataStore {
 		return partialTagIndex.lookup(partialTag, maxResults);
 	}
 
-	public LocalDate getDate(DateType source) {
+	public ZonedDateTime getDate(DateType source) {
 		if(dates != null) {
 			return dates.get(source);
 		}

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/data/SearchResults.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/data/SearchResults.java
@@ -18,6 +18,7 @@ package ca.bc.gov.ols.geocoder.api.data;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -77,7 +78,7 @@ public class SearchResults {
 	private BigDecimal executionTime;
 	
 	@XmlElement
-	private LocalDate processingDate;
+	private ZonedDateTime processingDate;
 	
 	@XmlElement
 	private String disclaimer;
@@ -108,7 +109,7 @@ public class SearchResults {
 	 * @param matches the results that matched the query
 	 * @param processingDate the date
 	 */
-	public SearchResults(GeocodeQuery query, List<GeocodeMatch> matches, LocalDate processingDate) {
+	public SearchResults(GeocodeQuery query, List<GeocodeMatch> matches, ZonedDateTime processingDate) {
 		this.queryAddress = query.getQueryAddress();
 		this.matches = matches;
 		this.maxResults = query.getMaxResults();
@@ -217,7 +218,7 @@ public class SearchResults {
 		this.locationDescriptor = locationDescriptor;
 	}
 
-	public LocalDate getProcessingDate() {
+	public ZonedDateTime getProcessingDate() {
 		return processingDate;
 	}
 }

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/FileGeocoderDataSource.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/FileGeocoderDataSource.java
@@ -21,7 +21,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
@@ -53,7 +53,7 @@ public class FileGeocoderDataSource implements GeocoderDataSource {
 	private final static Logger logger = LoggerFactory.getLogger(GeocoderConfig.LOGGER_PREFIX + 
 			FileGeocoderDataSource.class.getCanonicalName());
 	
-	private final static DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+	//private final static DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 	
 	private GeocoderConfig config;
 	private GeometryFactory geometryFactory;
@@ -269,8 +269,8 @@ public class FileGeocoderDataSource implements GeocoderDataSource {
 	}
 
 	@Override
-	public Map<DateType, LocalDate> getDates() {
-		Map<DateType, LocalDate> dates = new EnumMap<DateType, LocalDate>(DateType.class);
+	public Map<DateType, ZonedDateTime> getDates() {
+		Map<DateType, ZonedDateTime> dates = new EnumMap<DateType, ZonedDateTime>(DateType.class);
 		boolean ok = true;
 		for(Entry<String, Map<String, String>> dateSet : allDates.entrySet()) {
 			String file = dateSet.getKey();
@@ -283,9 +283,9 @@ public class FileGeocoderDataSource implements GeocoderDataSource {
 				String source = dateEntry.getKey();
 				DateType sourceType = null;
 				String dateStr = dateEntry.getValue();
-				LocalDate date = null;
+				ZonedDateTime date = null;
 				try {
-					date = LocalDate.parse(dateStr, DATE_FORMATTER);
+					date = ZonedDateTime.parse(dateStr);
 				} catch(DateTimeParseException pe) {
 					logger.error("Invalid Date '" + dateStr + "' for source '" + source +"' from file '" + file + "'.");
 				}

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/GeocoderDataSource.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/GeocoderDataSource.java
@@ -15,7 +15,7 @@
  */
 package ca.bc.gov.ols.geocoder.datasources;
 
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -71,7 +71,7 @@ public interface GeocoderDataSource {
 	
 	RowReader getOccupants();
 		
-	Map<DateType, LocalDate> getDates();
+	Map<DateType, ZonedDateTime> getDates();
 	
 	GeocoderConfig getConfig();
 	

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/TestDataSource.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/TestDataSource.java
@@ -16,11 +16,13 @@
 package ca.bc.gov.ols.geocoder.datasources;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.slf4j.Logger;
@@ -430,7 +432,7 @@ public class TestDataSource implements GeocoderDataSource {
 	}
 
 	@Override
-	public Map<DateType, LocalDate> getDates() {
+	public Map<DateType, ZonedDateTime> getDates() {
 		return null;
 	}
 

--- a/ols-geocoder-process/pom.xml
+++ b/ols-geocoder-process/pom.xml
@@ -55,11 +55,6 @@
 			<type>jar</type>
 		</dependency>
 		<dependency>
-			<groupId>ca.bc.gov.ols</groupId>
-			<artifactId>ols-util</artifactId>
-			<version>1.3.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<version>1.2.0</version>

--- a/ols-geocoder-process/src/main/java/ca/bc/gov/ols/rangebuilder/RangeBuilder.java
+++ b/ols-geocoder-process/src/main/java/ca/bc/gov/ols/rangebuilder/RangeBuilder.java
@@ -16,7 +16,7 @@
 package ca.bc.gov.ols.rangebuilder;
 
 import java.io.File;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -479,8 +479,15 @@ public class RangeBuilder {
 		}
 		logWriter.close();
 
+		// convert date map to strings
+		Map<DateType, ZonedDateTime> dates = dataSource.getDates();
+		Map<String, String> stringDates = new HashMap<String, String>();
+		for(Entry<DateType, ZonedDateTime> entry : dates.entrySet()) {
+			stringDates.put(entry.getKey().name(), entry.getValue().toString());
+		}
+		
 		logger.info("Writing output segments/sites");
-		writeRanges(segmentIdMap, extraSites, outputDataDir, dataSource.getDates(), "");
+		writeRanges(segmentIdMap, extraSites, outputDataDir, stringDates, "");
 
 		dataSource.close();
 	}
@@ -1408,7 +1415,7 @@ public class RangeBuilder {
 	}
 
 	public void writeRanges(TIntObjectHashMap<RbStreetSegment> segmentIdMap, List<IRbSite> extraSites,
-			String baseFilePathString, Map<DateType, LocalDate> dates, String tableSuffix) {
+			String baseFilePathString, Map<String, String> dates, String tableSuffix) {
 		File streetsFile = new File(baseFilePathString + "street_load_street_segments_geocoder.json");
 		RowWriter streetWriter = new JsonRowWriter(streetsFile, "bgeo_street_segments", dates);
 		File sitesFile = new File(baseFilePathString + "site_Hybrid_geocoder.tsv");

--- a/ols-geocoder-process/src/main/java/ca/bc/gov/ols/siteloaderprep/SiteLoaderPrep.java
+++ b/ols-geocoder-process/src/main/java/ca/bc/gov/ols/siteloaderprep/SiteLoaderPrep.java
@@ -926,7 +926,7 @@ public class SiteLoaderPrep {
 	}
 	
 	private static String addTrailingSeparator(String path) {
-		if(path.charAt(path.length()-1) == File.separatorChar){
+		if(path.charAt(path.length()-1) == File.separatorChar) {
 		    return path;
 		}
 		return path += File.separator;

--- a/ols-geocoder-process/src/main/java/ca/bc/gov/ols/streetprep/StreetPrep.java
+++ b/ols-geocoder-process/src/main/java/ca/bc/gov/ols/streetprep/StreetPrep.java
@@ -6,7 +6,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -67,7 +66,7 @@ public class StreetPrep {
 	private static final int SRID = 3005;
 	
 	// input filenames
-	private static final String VERSION_FILE = "version.tsv";
+	private static final String VERSION_FILE = "VERSION.tsv";
 	private static final String TRANSPORT_LINE_DEMOGRAPHIC_FILE = "TRANSPORT_LINE_DEMOGRAPHIC.tsv";
 	private static final String STRUCTURED_NAME_FILE = "STRUCTURED_NAME.tsv";
 	private static final String NAME_PREFIX_CODE_FILE = "NAME_PREFIX_CODE.tsv";
@@ -426,11 +425,10 @@ public class StreetPrep {
 	}
 	
 	private ZonedDateTime readVersion() {
-		try (BufferedReader reader = new BufferedReader(new FileReader(inputDir + VERSION_FILE))) {
-			String line = reader.readLine();
-			return ZonedDateTime.parse(line);
-		} catch(IOException ioe) {
-			throw new RuntimeException(ioe);
+		try (RowReader rr = new TsvRowReader(inputDir + VERSION_FILE, geometryFactory)) {
+			rr.next();
+			String date = rr.getString("VERSION");
+			return ZonedDateTime.parse(date);
 		}
 	}
 	

--- a/ols-geocoder-web/pom.xml
+++ b/ols-geocoder-web/pom.xml
@@ -39,17 +39,16 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.7.25</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.25</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/messageconverters/GmlOlsResponseConverter.java
+++ b/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/messageconverters/GmlOlsResponseConverter.java
@@ -125,7 +125,7 @@ public class GmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 						+ escape(GeocoderConfig.VERSION)
 						+ "</bgeo:version>\n"
 						+ "<bgeo:baseDataDate>"
-						+ escape(results.getProcessingDate())
+						+ escape(results.getProcessingDate().format(OlsResponseReader.DATE_FORMATTER))
 						+ "</bgeo:baseDataDate>\n"
 						+ "<bgeo:disclaimer>"
 						+ escape(config.getDisclaimer())

--- a/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/messageconverters/KmlOlsResponseConverter.java
+++ b/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/messageconverters/KmlOlsResponseConverter.java
@@ -48,35 +48,35 @@ import ca.bc.gov.ols.geocoder.util.GeocoderUtil;
 
 @Component
 public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsResponse> {
-	
+
 	private static final String GEOCODED = "geocoded";
 	private static final String REVERSE = "reverse";
-	
+
 	@Autowired
 	private IGeocoder geocoder;
 	private OlsResponse response;
-	
+
 	public KmlOlsResponseConverter() {
 		super(new MediaType("application", "vnd.google-earth.kml+xml",
 				Charset.forName("UTF-8")));
 	}
-	
+
 	@Override
 	protected boolean supports(Class<?> clazz) {
 		return OlsResponse.class.isAssignableFrom(clazz);
 	}
-	
+
 	@Override
 	public boolean canRead(Class<?> clazz, MediaType mediaType) {
 		return false;
 	}
-	
+
 	@Override
 	protected OlsResponse readInternal(Class<? extends OlsResponse> clazz,
 			HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
 		return null;
 	}
-	
+
 	@Override
 	protected void writeInternal(OlsResponse response, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
@@ -113,7 +113,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 		out.write(("</Document>\r\n</kml>"));
 		out.flush();
 	}
-	
+
 	String singleSiteDocHeader(SiteAddress addr, GeocoderConfig config, OlsResponse response) {
 		return "<Document>\r\n"
 				+ "<name>Results for " + escape(addr.getAddressString()) + "</name>\r\n"
@@ -134,12 +134,12 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ escape(config.getCopyrightLicense())
 				+ "</value></Data>\r\n"
 				+ "</ExtendedData>\r\n"
-				+ "<styleUrl>" 
-				+ (response.getExtraInfo("occupantQuery").equals("true") ? 
-						config.getOccupantCategoryKmlStyleUrl() : config.getKmlStylesUrl())  
+				+ "<styleUrl>"
+				+ (response.getExtraInfo("occupantQuery").equals("true") ?
+						config.getOccupantCategoryKmlStyleUrl() : config.getKmlStylesUrl())
 				+ "#reverse_results_heading</styleUrl>\r\n";
 	}
-	
+
 	String singleIntersectionDocHeader(StreetIntersectionAddress intersection,
 			GeocoderConfig config, OlsResponse response) {
 		return "<Document>\r\n"
@@ -168,7 +168,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ "<styleUrl>" + config.getKmlStylesUrl()
 				+ "#reverse_intersection_results_heading</styleUrl>\r\n";
 	}
-	
+
 	String searchResultsToKML(SearchResults results, GeocoderConfig config,
 			OlsResponse response) {
 		// TODO need to handle date formatting
@@ -183,7 +183,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ "</value></Data>\r\n"
 				+ "<Data name=\"version\"><value>" + escape(GeocoderConfig.VERSION)
 				+ "</value></Data>\r\n"
-				+ "<Data name=\"baseDataDate\"><value>" + escape(results.getProcessingDate())
+				+ "<Data name=\"baseDataDate\"><value>" + escape(results.getProcessingDate().format(OlsResponseReader.DATE_FORMATTER))
 				+ "</value></Data>\r\n"
 				+ "<Data name=\"minScore\"><value>" + escape(results.getMinScore())
 				+ "</value></Data>\r\n"
@@ -209,9 +209,9 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ escape(config.getCopyrightLicense())
 				+ "</value></Data>\r\n"
 				+ "</ExtendedData>\r\n"
-				+ "<styleUrl>" 
-				+ (response.getExtraInfo("occupantQuery").equals("true") ? 
-						config.getOccupantCategoryKmlStyleUrl() : config.getKmlStylesUrl())  
+				+ "<styleUrl>"
+				+ (response.getExtraInfo("occupantQuery").equals("true") ?
+						config.getOccupantCategoryKmlStyleUrl() : config.getKmlStylesUrl())
 				+ "#results_heading</styleUrl>\r\n");
 		Iterator<GeocodeMatch> it = results.getMatches().iterator();
 		while(it.hasNext()) {
@@ -220,7 +220,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 		buf.append("");
 		return buf.toString();
 	}
-	
+
 	String geocodeMatchToKML(GeocodeMatch match, GeocoderConfig config) {
 		if(match instanceof AddressMatch) {
 			return addressMatchToKML((AddressMatch)match, config);
@@ -229,7 +229,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 		}
 		return "";
 	}
-	
+
 	String addressMatchToKML(AddressMatch match, GeocoderConfig config) {
 		SiteAddress addr = match.getAddress();
 		String occupantStr = "";
@@ -360,7 +360,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ "</Placemark>";
 		return result;
 	}
-	
+
 	private String getStyleUrl(GeocoderConfig config, String type,
 			GeocoderAddress addr) {
 		if(addr instanceof OccupantAddress) {
@@ -374,7 +374,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 		return config.getKmlStylesUrl() + "#" + type + "_" + addr.getLocationDescriptor() + "_"
 				+ addr.getLocationPositionalAccuracy().toString();
 	}
-	
+
 	private String getLookAt(GeocoderAddress addr, GeocoderConfig config) {
 		if(addr.getLocation() == null) {
 			return "";
@@ -383,9 +383,9 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				"<latitude>" + addr.getLocation().getY() + "</latitude>" +
 				"<altitude>0</altitude><heading>0</heading><tilt>0</tilt>" +
 				"<range>" + config.getDefaultLookAtRange() + "</range>" + "</LookAt>\r\n";
-		
+
 	}
-	
+
 	private String getPoint(ILocation loc) {
 		if(loc.getLocation() == null) {
 			return "";
@@ -434,7 +434,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ getPoint(addr)
 				+ "</Placemark>\r\n";
 	}
-	
+
 	String siteAddressesToKML(SiteAddress[] addrs, GeocoderConfig config,
 			OlsResponse response) {
 		StringBuilder buf = new StringBuilder("<Document>\r\n"
@@ -450,12 +450,12 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ "</value></Data>\r\n"
 				+ "<Data name=\"executionTime\"><value>" + response.getExtraInfo("executionTime")
 				+ "</value></Data>\r\n"
-				+ (response.getExtraInfo("tags").isEmpty() ? "" : "<Data name=\"tags\"><value>" 
+				+ (response.getExtraInfo("tags").isEmpty() ? "" : "<Data name=\"tags\"><value>"
 						+ response.getExtraInfo("tags") + "</value></Data>\r\n")
+				+ "<Data name=\"disclaimer\"><value>"
 				+ escape(config.getDisclaimer()) + "</value></Data>\r\n"
 				+ "<Data name=\"privacyStatement\"><value>"
 				+ escape(config.getPrivacyStatement()) + "</value></Data>\r\n"
-				+ escape("http://www2.gov.bc.ca/gov/admin/privacy.page") + "</value></Data>\r\n"
 				+ "<Data name=\"copyrightNotice\"><value>"
 				+ escape(config.getCopyrightNotice())
 				+ "</value></Data>\r\n"
@@ -463,16 +463,16 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ escape(config.getCopyrightLicense())
 				+ "</value></Data>\r\n"
 				+ "</ExtendedData>\r\n"
-				+ "<styleUrl>" 
-				+ (response.getExtraInfo("occupantQuery").equals("true") ? 
-						config.getOccupantCategoryKmlStyleUrl() : config.getKmlStylesUrl())  
+				+ "<styleUrl>"
+				+ (response.getExtraInfo("occupantQuery").equals("true") ?
+						config.getOccupantCategoryKmlStyleUrl() : config.getKmlStylesUrl())
 				+ "#reverse_results_heading</styleUrl>\r\n");
 		for(SiteAddress addr : addrs) {
 			buf.append(siteAddressToKML(addr, config));
 		}
 		return buf.toString();
 	}
-	
+
 	String siteAddressToKML(SiteAddress addr, GeocoderConfig config) {
 		String occupantStr = "";
 		if(addr instanceof OccupantAddress) {
@@ -581,7 +581,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ getPoint(addr)
 				+ "</Placemark>";
 	}
-	
+
 	String streetIntersectionAddressesToKML(StreetIntersectionAddress[] addrs,
 			GeocoderConfig config, OlsResponse response) {
 		StringBuilder buf = new StringBuilder("<Document>\r\n"
@@ -616,7 +616,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 		}
 		return buf.toString();
 	}
-	
+
 	String streetIntersectionAddressToKML(StreetIntersectionAddress addr,
 			GeocoderConfig config) {
 		return "<Placemark>\r\n"
@@ -648,7 +648,7 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 				+ getPoint(addr)
 				+ "</Placemark>";
 	}
-	
+
 
 	String escape(Object field) {
 		if(field == null) {
@@ -657,5 +657,5 @@ public class KmlOlsResponseConverter extends AbstractHttpMessageConverter<OlsRes
 		field = OlsResponseWriter.formatDate(field);
 		return StringEscapeUtils.escapeXml10(field.toString());
 	}
-	
+
 }

--- a/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/messageconverters/OlsResponseReader.java
+++ b/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/messageconverters/OlsResponseReader.java
@@ -16,6 +16,7 @@
 package ca.bc.gov.ols.geocoder.rest.messageconverters;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 
 import ca.bc.gov.ols.geocoder.api.data.AddressMatch;
@@ -34,6 +35,7 @@ import ca.bc.gov.ols.geocoder.util.GeocoderUtil;
 
 public class OlsResponseReader {
 
+	public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
 	private OlsResponse response;
 	private OlsResponseWriter writer;
 	private GeocoderConfig config;
@@ -94,7 +96,7 @@ public class OlsResponseReader {
 		writer.field("searchTimestamp", results.getSearchTimeStamp());
 		writer.field("executionTime", results.getExecutionTime());
 		writer.field("version", GeocoderConfig.VERSION);
-		writer.field("baseDataDate", results.getProcessingDate());
+		writer.field("baseDataDate", results.getProcessingDate().format(DATE_FORMATTER));
 		writer.field("srsCode", results.getSrsCode());
 		writer.field("interpolation", results.getInterpolation());
 		writer.field("echo", results.getIsEcho());

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <springframework.security.version>5.3.4.RELEASE</springframework.security.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>
 		<maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
-		<slf4j.version>1.7.21</slf4j.version>
+		<slf4j.version>1.7.25</slf4j.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Updates streetPrep to read in the ITN export date from version.tsv, and changes throughout geocoder to handle the full ISO date/time value but it is still output as yyyy-MM-dd in the geocoder response to remain backward compatible. Note that the version has also been updated to 4.3.0 but this does not include all the 4.3 changes, only the changes required for route planner 2.2