### PR TITLE
gh-pages update: What's New and ALMA score

### DIFF
--- a/address-list-match-accuracy.md
+++ b/address-list-match-accuracy.md
@@ -11,4 +11,4 @@ The numbers below were calculated using the same test dataset for consistency to
 |4.1 (bronze)|70|Added abbreviations and non-adjacent locality aliases. Also includes the first attempt at removing garbage words with confidence, handling of multiple spelling errors, and the detection of more types of postal address elements.|
 |4.1 (silver)|75|Removed redundant BCGNIS localities and StatsCan RNF address ranges; Added unit descriptors. Also includes better garbage word removal, handling of unitNumber stuck to unitDescriptor, handling of detached suffix in a numbered street-name, reducing locality-hopping, penalizing unmatched suffixes during autocompletion, better handling of special characters, and fine tuning the scoring system.|
 |4.2|79.53|What’s new:  https://github.com/bcgov/ols-geocoder/blob/gh-pages/whats-new.md|
-|4.3|79.53|What’s new:  https://github.com/bcgov/ols-geocoder/blob/gh-pages/whats-new.md|
+|4.3|79.98|What’s new:  https://github.com/bcgov/ols-geocoder/blob/gh-pages/whats-new.md|

--- a/whats-new.md
+++ b/whats-new.md
@@ -3,7 +3,7 @@
 Check out the Geocoder release [roadmap](https://github.com/bcgov/ols-geocoder/blob/gh-pages/roadmap.md)
 For detailed API release notes, see the [BC Geocoder Developer Guide](https://github.com/bcgov/api-specs/blob/master/geocoder/geocoder-developer-guide.md)
 
-## January, 2024
+## February 6, 2024
 - BC Address Geocoder version 4.3.0
 - Improved recognition of addresses containing PO boxes.
 - Improved response for cases where no site is found.


### PR DESCRIPTION
Updated the What's New page to include the 4.3 PROD migration date.
Updated the ALMA score for the latest 4.3 test using the Batch Geocoder.