### PR TITLE
New FuzzyMatch Parameter

### DIFF
--- a/ols-geocoder-core/pom.xml
+++ b/ols-geocoder-core/pom.xml
@@ -106,5 +106,10 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.12.0</version>
 		</dependency>
+		<dependency>
+    		<groupId>com.github.xdrop</groupId>
+    		<artifactId>fuzzywuzzy</artifactId>
+    		<version>1.4.0</version>
+		</dependency>
     </dependencies>
 </project>

--- a/ols-geocoder-core/pom.xml
+++ b/ols-geocoder-core/pom.xml
@@ -107,7 +107,7 @@
 			<version>3.12.0</version>
 		</dependency>
 		<dependency>
-    		<groupId>com.github.xdrop</groupId>
+    		<groupId>me.xdrop</groupId>
     		<artifactId>fuzzywuzzy</artifactId>
     		<version>1.4.0</version>
 		</dependency>

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocodeResultsHandler.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocodeResultsHandler.java
@@ -54,8 +54,7 @@ public class GeocodeResultsHandler implements ParseDerivationHandler {
 		this.query = query;
 		this.geocoder = geocoder;
 		this.datastore = geocoder.getDatastore();
-		//matches = new ArrayList<GeocodeMatch>();
-		matches = new UniquePriorityQueue<GeocodeMatch>(query.getMaxResults() + 1, GeocodeMatch.SCORE_COMPARATOR.reversed());
+		matches = new UniquePriorityQueue<GeocodeMatch>(query.getNumPrelimResults(), GeocodeMatch.SCORE_COMPARATOR.reversed());
 	}
 	
 	@Override

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
@@ -80,6 +80,8 @@ import ca.bc.gov.ols.util.StringUtils;
 
 import org.locationtech.jts.geom.Coordinate;
 
+import me.xdrop.fuzzywuzzy.FuzzySearch;
+
 /**
  * The Geocoder takes GeocodeQueries and uses the GeocoderDataStore to return GeocodeResults.
  * 
@@ -251,12 +253,23 @@ public class Geocoder implements IGeocoder {
 		}
 		
 
-		// Mike: sort by length if score is the same
+		// Mike: sort by length/fuzzy if score is the same
 
-		matches.sort(
-    		Comparator.comparingInt(GeocodeMatch::getScore).reversed() // Sort by score in descending order
-            	.thenComparingInt(match -> match.getAddressString() != null ? match.getAddressString().length() : 0) // Then by length in ascending order
-		);
+		// matches.sort(
+    	// 	Comparator.comparingInt(GeocodeMatch::getScore).reversed() // Sort by score in descending order
+        //     	.thenComparingInt(match -> match.getAddressString() != null ? match.getAddressString().length() : 0) // Then by length in ascending order
+		// );
+
+		if(query.getAddressString() != null && !query.getAddressString().isEmpty()) {
+			matches.sort(
+        		Comparator.comparingInt(GeocodeMatch::getScore).reversed() // Primary sort by score (descending)
+                	.thenComparingInt((GeocodeMatch match) -> 
+                    	FuzzySearch.ratio(query.getAddressString(), match.getAddressString() != null ? match.getAddressString() : "")
+                  	).reversed() // Break ties by fuzzy score (higher fuzzy score is better)
+    		);
+		}
+		
+    );
 
 
 

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
@@ -250,6 +250,16 @@ public class Geocoder implements IGeocoder {
 			}
 		}
 		
+
+		// Mike: sort by length if score is the same
+
+		matches.sort(
+    		Comparator.comparingInt(GeocodeMatch::getScore).reversed() // Sort by score in descending order
+            	.thenComparingInt(match -> match.getAddressString() != null ? match.getAddressString().length() : 0) // Then by length in ascending order
+		);
+
+
+
 //		logger.debug("matches.size() before duplicate filter: {}", matches.size());
 //		
 //		// filter out any duplicate results, keep the one with the highest score

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
@@ -81,6 +81,7 @@ public class GeocodeQuery extends SharedParameters{
 	private boolean includeOccupants = false;
 	private boolean autoComplete = false;
 	private boolean exactSpelling = false;
+	private boolean fuzzyMatch = false;
 
 	public GeocodeQuery() {
 		setMaxResults(1);
@@ -411,6 +412,14 @@ public class GeocodeQuery extends SharedParameters{
 		this.autoComplete = autoComplete;
 	}
 
+	public boolean isFuzzyMatch() {
+		return fuzzyMatch;
+	}
+
+	public void setFuzzyMatch(boolean fuzzyMatch) {
+		this.fuzzyMatch = fuzzyMatch;
+	}
+
 	public boolean getExactSpelling() {
 		return exactSpelling;
 	}
@@ -418,6 +427,14 @@ public class GeocodeQuery extends SharedParameters{
 	public void setExactSpelling(boolean exactSpelling) {
 		this.exactSpelling = exactSpelling;
 	}
+
+	public int getNumPrelimResults() {
+		if(fuzzyMatch) {
+			return 100;
+		}
+		return getMaxResults() + 1;
+	}
+
 
 	public boolean pass(GeocodeMatch match) {
 		if(filter == null) {

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/data/GeocodeMatch.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/data/GeocodeMatch.java
@@ -95,10 +95,7 @@ public abstract class GeocodeMatch implements ModifiableLocation {
 	};
 	
 	public static final Comparator<GeocodeMatch> ADDRESS_STRING_COMPARATOR = Comparator
-	        .comparing(GeocodeMatch::getAddressString, Comparator.nullsFirst(String::compareToIgnoreCase))
-			.thenComparingInt(match -> match.getAddressString().length());
-    		
-
+	        .comparing(GeocodeMatch::getAddressString, Comparator.nullsFirst(String::compareToIgnoreCase));
 	
 	@XmlElement(nillable = true)
 	protected int score;

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/data/GeocodeMatch.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/data/GeocodeMatch.java
@@ -95,7 +95,10 @@ public abstract class GeocodeMatch implements ModifiableLocation {
 	};
 	
 	public static final Comparator<GeocodeMatch> ADDRESS_STRING_COMPARATOR = Comparator
-	        .comparing(GeocodeMatch::getAddressString, Comparator.nullsFirst(String::compareToIgnoreCase));
+	        .comparing(GeocodeMatch::getAddressString, Comparator.nullsFirst(String::compareToIgnoreCase))
+			.thenComparingInt(match -> match.getAddressString().length());
+    		
+
 	
 	@XmlElement(nillable = true)
 	protected int score;

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/ExactMatchLookup.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/ExactMatchLookup.java
@@ -35,7 +35,7 @@ public class ExactMatchLookup {
 		List<GeocodeMatch> results = new ArrayList<GeocodeMatch>(query.getMaxResults() + 1);
 		int pos = Collections.binarySearch(table, new StringOnlyGeocodeMatch(addressString), GeocodeMatch.ADDRESS_STRING_COMPARATOR);
 		pos = Math.abs(pos) - 1;
-		for(int i = pos; results.size() < query.getMaxResults() + 1; i++) {
+		for(int i = pos; results.size() < query.getNumPrelimResults(); i++) {
 			GeocodeMatch match = table.get(i);
 			if(match.getAddressString().substring(0, addressString.length()).equalsIgnoreCase(addressString)) {
 				if(query.pass(match)) {

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/UniquePriorityQueue.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/UniquePriorityQueue.java
@@ -4,6 +4,18 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.PriorityQueue;
 
+/**
+ * The UniquePriorityQueue combines a HashMap with a PriorityQueue to
+ * keep track of geocoding results ordered by score, while preventing duplicates
+ * (keeping the highest scoring version of any equal results).
+ * 
+ * Also has a max count to prevent using too much memory for results 
+ * that will never be returned (low scores fall off the end of the queue).
+ * 
+ * The Comparator is used for the prioritization/ordering (by "score").
+ * 
+ * @param <T> Intended to be used with GeocodeResult, but in theory any class with a valid hash function and a comparator can be used  
+ */
 public class UniquePriorityQueue<T> {
 
 	private final int max;
@@ -11,6 +23,12 @@ public class UniquePriorityQueue<T> {
 	private final PriorityQueue<T> q;
 	private final HashMap<T,T> m;
 	
+	/**
+	 * Creates a new UniquePriorityQueue with the give maximum size and comparator.
+	 * 
+	 * @param max the maximum number of items to store in the queue 
+	 * @param c The comparator to use for the prioritization/ordering
+	 */
 	public UniquePriorityQueue(int max, Comparator<T> c) {
 		this.max = max;
 		this.c = c;
@@ -18,6 +36,12 @@ public class UniquePriorityQueue<T> {
 		m = new HashMap<T,T>(max);
 	}
 	
+	/**
+	 * Adds an item to the queue. If an "equal()" item had already been added, only
+	 * the highest valued item (according to the comparator) is kept.
+	 * 
+	 * @param item the item to add to the queue
+	 */
 	public void add(T item) {
 		T existing = m.get(item);
 		// if the item being added is a duplicate
@@ -40,19 +64,33 @@ public class UniquePriorityQueue<T> {
 		}
 	}
 
+	/**
+	 * Clears the queue of all items.
+	 */
 	public void clear() {
 		q.clear();
 		m.clear();
 	}
 	
+	/**
+	 * @return The number of items in the queue
+	 */
 	public int size() {
 		return q.size();
 	}
 	
+	/**
+	 * @return True if the queue is empty, false otherwise
+	 */
 	public boolean isEmpty() {
 		return q.isEmpty();
 	}
 	
+	/**
+	 * Pops the lowest scored item (according to the comparator) off of the front of the queue.
+	 * 
+	 * @return the lowest scoring item in the queue, or null if the queue is empty
+	 */
 	public T poll() {
 		T item = q.poll();
 		if(item != null) {


### PR DESCRIPTION
If you enable fuzzyMatch=true the geocoder initially ignores the maxResults parameter and instead gathers the best 100 matches, then reorders those matches using a fuzzyMatch comparison to the queryAddress, and then returns the best maxResults results from that list.