### PR TITLE
Geocoder 4.5 documentation updates

### DIFF
--- a/geocoder-developer-guide.md
+++ b/geocoder-developer-guide.md
@@ -239,11 +239,13 @@ The *faults* property in a resource response is a list of one or more address ma
 <br><br>
 <a name=implementingautocomplete></a>
 ## Implementing address autocompletion in your application
-Using the autoComplete boolean request parameter is the key to successful implementation of address autocompletion in your application. Let's assume your application input form has an address text box and a search icon. 
+Using the [autoComplete](https://github.com/bcgov/ols-geocoder/blob/gh-pages/glossary.md#autoComplete) boolean request parameter is the key to successful implementation of address autocompletion in your application. Let's assume your application input form has an address text box and a search icon. 
 
-A user starts entering the characters of an address. After three or so characters, the application should issue a get request on the addresses resource with autoComplete set to True every time a user enters an additional character. This tells the geocoder that addressString contains a partial address and to find the best N address prefix matches for display in a pick list below the address text box.
+A user starts entering the characters of an address. After three or so characters, the application should issue a get request on the addresses resource with autoComplete set to true every time a user enters an additional character. This tells the geocoder that addressString contains a partial address and to find the best N address prefix matches for display in a pick list below the address text box.
 
-If the user clicks on the search icon or presses the Enter key, the application should issue a get request on the addresses resource with autocomplete set to False. This tells the geocoder to use addressString as entered when trying to find the best N matches.
+If the user clicks on the search icon or presses the Enter key, the application should issue a get request on the addresses resource with autoComplete set to False. This tells the geocoder to use addressString as entered when trying to find the best N matches.
+
+You can also use the autoComplete and [exactSpelling](https://github.com/bcgov/ols-geocoder/blob/gh-pages/glossary.md#exactSpelling) parameters in the same request. If exactSpelling is set to true (default is false), autoComplete suggestions will be limited to addresses beginning with the provided partial address. 
 
 If you are using jQuery in your javascript app, check out our javascript code for autocompletion [here](https://github.com/bcgov/ols-devkit/tree/gh-pages/widget). To see the code in action, visit [here](https://bcgov.github.io/ols-devkit/examples/address_autocomplete.html)
 

--- a/glossary.md
+++ b/glossary.md
@@ -32,7 +32,7 @@ Term | Definition
 <a name="echo">echo</a> | Include unmatched address details such as site name in results.
 <a name="electoralArea">electoralArea</a> | The name of the Electoral Area a physical address is located in. Is empty if address is located in a municipality. An Electoral Area is an administrative area within a [Regional-District](http://www.cscd.gov.bc.ca/lgd/pathfinder-rd.htm) in British Columbia.
 <a name="endDate">endDate</a> | The ending date of a time period formatted as YYYY-MM-DD.
-<a name="exactSpelling">exactSpelling</a> | If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.
+<a name="exactSpelling">exactSpelling</a> | If true, autoComplete suggestions are limited to addresses beginning with the provided partial address. The default is false.
 <a name="excludeUnits">excludeUnits</a> | If true, excludes sites that are units of a parent site.
 <a name="executionTime">executionTime</a> | Query execution time in milliseconds
 <a name="extrapolate">extrapolate</a> | If true, uses supplied parcelPoint to derive an appropriate accessPoint. If extrapolate=true and no parcelPoint is provided or if extrapolate= false and a parcelPoint is provided, no extrapolation is performed and locationDescriptor is used to determine type of point to return.

--- a/glossary.md
+++ b/glossary.md
@@ -31,7 +31,8 @@ Term | Definition
 <a name="degree">degree</a> | The number of road segments that intersection at an intersection. The degree of a dead-end is 1. The degree of a 4-way intersection is 4.
 <a name="echo">echo</a> | Include unmatched address details such as site name in results.
 <a name="electoralArea">electoralArea</a> | The name of the Electoral Area a physical address is located in. Is empty if address is located in a municipality. An Electoral Area is an administrative area within a [Regional-District](http://www.cscd.gov.bc.ca/lgd/pathfinder-rd.htm) in British Columbia.
-<a name="endDate">endDate</a> | The ending date of a time period formatted as YYYY-MM-DD .
+<a name="endDate">endDate</a> | The ending date of a time period formatted as YYYY-MM-DD.
+<a name="exactSpelling">exactSpelling</a> | If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.
 <a name="excludeUnits">excludeUnits</a> | If true, excludes sites that are units of a parent site.
 <a name="executionTime">executionTime</a> | Query execution time in milliseconds
 <a name="extrapolate">extrapolate</a> | If true, uses supplied parcelPoint to derive an appropriate accessPoint. If extrapolate=true and no parcelPoint is provided or if extrapolate= false and a parcelPoint is provided, no extrapolation is performed and locationDescriptor is used to determine type of point to return.


### PR DESCRIPTION
Minor updates to the glossary of terms and developer guide to include the exactSpelling parameter.