### PR TITLE
Updated ALMA summary

### DIFF
--- a/address-list-match-accuracy.md
+++ b/address-list-match-accuracy.md
@@ -10,8 +10,8 @@ A list of changes per release can be found on the [What's New](https://github.co
 |:------------------|:-----:|:-----|
 | 4.02 (prod baseline) | 58    |
 | 4.02              | 60    | Added adjacent localities as aliases, ITN address ranges, glued and unglued street names as aliases, streets with directionals in name as aliases; changed BCGNIS localities that aren't DRA localities from localities to sites within DRA localities.|
-| 4.1 (bronze)      | 70    | |
-| 4.1 (silver)      | 75    | |
+| 4.1 (bronze)      | 70    | Added abbreviations and non-adjacent locality aliases. Also includes the first attempt at removing garbage words with confidence, handling of multiple spelling errors, and the detection of more types of postal address elements. |
+| 4.1 (silver)      | 75    | Removed redundant BCGNIS localities and StatsCan RNF address ranges; Added unit descriptors. Also includes better garbage word removal, handling of unitNumber stuck to unitDescriptor, handling of detached suffix in a numbered street-name, reducing locality-hopping, penalizing unmatched suffixes during autocompletion, better handling of special characters, and fine tuning the scoring system. |
 | 4.2               | 79.53 | |
 | 4.3               | 79.98 | |
 | 4.5.1             | 80.06 | |


### PR DESCRIPTION
Updated ALMA summary to include a What's New link to remove redundant listing in the table. Also removed notes that were not covered by the What's New page.