### PR TITLE
What's new page - GC 4.5.2

### DIFF
--- a/whats-new.md
+++ b/whats-new.md
@@ -3,7 +3,7 @@
 Check out the Geocoder release [roadmap](https://github.com/bcgov/ols-geocoder/blob/gh-pages/roadmap.md)
 For detailed API release notes, see the [BC Geocoder Developer Guide](https://github.com/bcgov/api-specs/blob/master/geocoder/geocoder-developer-guide.md)
 
-## June 2025
+## June 24, 2025
 - BC Address Geocoder version 4.5.2
 - Bug fix for KML requests containing null values, leading to a 500 error
 


### PR DESCRIPTION
Updated the Geocoder what's new page to include the 4.5.2 release.