### PR TITLE
4.5.3 - Fuzzy Match bugs fixs and AND/OR in occupant tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ local.properties
 .idea
 
 local_data
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ local.properties
 
 # InelliJ
 .idea
+
+local_data

--- a/ols-geocoder-admin/pom.xml
+++ b/ols-geocoder-admin/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2</version>
+		<version>4.5.3</version>
 	</parent>
 
 	<name>OLS Geocoder Admin</name>

--- a/ols-geocoder-admin/pom.xml
+++ b/ols-geocoder-admin/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2-private-road</version>
+		<version>4.5.2</version>
 	</parent>
 
 	<name>OLS Geocoder Admin</name>

--- a/ols-geocoder-admin/pom.xml
+++ b/ols-geocoder-admin/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2</version>
+		<version>4.5.2-private-road</version>
 	</parent>
 
 	<name>OLS Geocoder Admin</name>

--- a/ols-geocoder-core/pom.xml
+++ b/ols-geocoder-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2-private-road</version>
+		<version>4.5.2</version>
 	</parent>
 
 	<name>OLS Geocoder Core</name>

--- a/ols-geocoder-core/pom.xml
+++ b/ols-geocoder-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2</version>
+		<version>4.5.3</version>
 	</parent>
 
 	<name>OLS Geocoder Core</name>

--- a/ols-geocoder-core/pom.xml
+++ b/ols-geocoder-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2</version>
+		<version>4.5.2-private-road</version>
 	</parent>
 
 	<name>OLS Geocoder Core</name>

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/Geocoder.java
@@ -252,12 +252,13 @@ public class Geocoder implements IGeocoder {
 		}
 
 		if(query.isFuzzyMatch() && query.getAddressString() != null && !query.getAddressString().isEmpty()) {
-			// sort by fuzzy score (higher fuzzy score is better)
+			final String normalizedInput = query.getAddressString().toLowerCase();
 			matches.sort(
 				Comparator.comparingInt((GeocodeMatch match) ->
-					FuzzySearch.ratio(query.getAddressString(), match.getAddressString())
+					FuzzySearch.ratio(normalizedInput, match.getAddressString().toLowerCase())
 				).reversed() 
 			);
+
 			matches = matches.subList(0, Math.min(query.getMaxResults(), matches.size()));
 		}
 

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
@@ -1461,6 +1461,8 @@ public class GeocoderDataStore {
 		// Special case to handle the fact that Rue needs to map to St for french
 		// but Rue is also a valid street type on its own
 		wordMapBuilder.addWordMapping("Rue", "St");
+		// Add Wye as a valid street type (railway term for Y-shaped track junction)
+		wordMapBuilder.addWord("Wye", WordClass.STREET_TYPE);
 		
 		// Add directionals
 		rr = dataSource.getStreetDirs();

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
@@ -471,11 +471,31 @@ public class GeocodeQuery extends SharedParameters{
 				@Override
 				public boolean pass(GeocodeMatch match) {
 					if(match instanceof AddressMatch 
-							&& ((AddressMatch)match).getAddress() instanceof OccupantAddress
-							&& ((OccupantAddress)(((AddressMatch)match).getAddress())).getKeywordList()
-									.containsAll(Arrays.asList(tags.toLowerCase().split(";")))
-							) {
-						return true;
+						&& ((AddressMatch)match).getAddress() instanceof OccupantAddress) {
+						List<String> keywords = ((OccupantAddress)(((AddressMatch)match).getAddress())).getKeywordList();
+						if(keywords == null || keywords.isEmpty()) {
+							return false;
+						}
+						String lowerTags = tags.toLowerCase();
+						// OR if tags contain ':'
+						if(lowerTags.contains(":")) {
+							String[] tagArray = lowerTags.split(":");
+							for(String t : tagArray) {
+								t = t.trim();
+								if(keywords.contains(t)) {
+									return true;
+								}
+							}
+							return false;
+						} else {
+							// default to AND using ';'
+							String[] tagArray = lowerTags.split(";");
+							List<String> required = new ArrayList<String>(tagArray.length);
+							for(String t : tagArray) {
+								required.add(t.trim());
+							}
+							return keywords.containsAll(required);
+						}
 					}
 					return false;
 				}

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
@@ -479,6 +479,7 @@ public class GeocodeQuery extends SharedParameters{
 			filters.add(new Filter<GeocodeMatch>() {
 				@Override
 				public boolean pass(GeocodeMatch match) {
+
 					if(match instanceof AddressMatch 
 						&& ((AddressMatch)match).getAddress() instanceof OccupantAddress) {
 						List<String> keywords = ((OccupantAddress)(((AddressMatch)match).getAddress())).getKeywordList();
@@ -499,9 +500,11 @@ public class GeocodeQuery extends SharedParameters{
 
 						if(useOr) {
 							String[] tagArray = lowerTags.split(";");
+							System.out.println(">>>>>>>> keywords: " + keywords + " : " + Arrays.toString(tagArray));
 							for(String t : tagArray) {
 								t = t.trim();
 								if(keywords.contains(t)) {
+									System.out.println(">>>>>>>> matched tag: " + t);
 									return true;
 								}
 							}

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
@@ -58,6 +58,7 @@ public class GeocodeQuery extends SharedParameters{
 	private String streetQualifier;
 	private String localityName;
 	private String stateProvTerr;
+	private String tagCondition;
 	
 	private int minScore = 0;
 	private EnumSet<MatchPrecision> matchPrecision = null;
@@ -428,6 +429,14 @@ public class GeocodeQuery extends SharedParameters{
 		this.exactSpelling = exactSpelling;
 	}
 
+	public String getTagCondition() {
+		return tagCondition;
+	}
+
+	public void setTagCondition(String tagCondition) {
+		this.tagCondition = tagCondition;
+	}
+
 	public int getNumPrelimResults() {
 		if(fuzzyMatch) {
 			return 100;
@@ -477,9 +486,19 @@ public class GeocodeQuery extends SharedParameters{
 							return false;
 						}
 						String lowerTags = tags.toLowerCase();
-						// OR if tags contain ':'
-						if(lowerTags.contains(":")) {
-							String[] tagArray = lowerTags.split(":");
+
+						boolean useOr = true;
+						if(tagCondition != null && !tagCondition.trim().isEmpty()) {
+							String c = tagCondition.trim().toLowerCase();
+							if(c.contains("or")) {
+								useOr = true;
+							} else if(c.contains("and")) {
+								useOr = false;
+							}
+						}
+
+						if(useOr) {
+							String[] tagArray = lowerTags.split(";");
 							for(String t : tagArray) {
 								t = t.trim();
 								if(keywords.contains(t)) {
@@ -488,7 +507,7 @@ public class GeocodeQuery extends SharedParameters{
 							}
 							return false;
 						} else {
-							// default to AND using ';'
+							// default
 							String[] tagArray = lowerTags.split(";");
 							List<String> required = new ArrayList<String>(tagArray.length);
 							for(String t : tagArray) {

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
@@ -491,9 +491,9 @@ public class GeocodeQuery extends SharedParameters{
 						boolean useOr = true;
 						if(tagCondition != null && !tagCondition.trim().isEmpty()) {
 							String c = tagCondition.trim().toLowerCase();
-							if(c.contains("or")) {
+							if("or".equals(c)) {
 								useOr = true;
-							} else if(c.contains("and")) {
+							} else if("and".equals(c)) {
 								useOr = false;
 							}
 						}

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
@@ -16,7 +16,6 @@
 package ca.bc.gov.ols.geocoder.api;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -500,11 +499,9 @@ public class GeocodeQuery extends SharedParameters{
 
 						if(useOr) {
 							String[] tagArray = lowerTags.split(";");
-							System.out.println(">>>>>>>> keywords: " + keywords + " : " + Arrays.toString(tagArray));
 							for(String t : tagArray) {
 								t = t.trim();
 								if(keywords.contains(t)) {
-									System.out.println(">>>>>>>> matched tag: " + t);
 									return true;
 								}
 							}

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/api/GeocodeQuery.java
@@ -510,7 +510,7 @@ public class GeocodeQuery extends SharedParameters{
 							}
 							return false;
 						} else {
-							// default
+							// AND logic
 							String[] tagArray = lowerTags.split(";");
 							List<String> required = new ArrayList<String>(tagArray.length);
 							for(String t : tagArray) {

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/TagIndex.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/TagIndex.java
@@ -82,7 +82,11 @@ public class TagIndex<T> {
 			if(results == null) {
 				results = new THashSet<T>(tie.items);
 			} else {
-				results.retainAll(tie.items);
+				// intersect the results with the next tag's items (AND)
+				// results.retainAll(tie.items);
+
+				// union logic (OR) would be:
+				results.addAll(tie.items);
 			}
 		}
 		if(results == null) {

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/TagIndex.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/TagIndex.java
@@ -82,11 +82,7 @@ public class TagIndex<T> {
 			if(results == null) {
 				results = new THashSet<T>(tie.items);
 			} else {
-				// intersect the results with the next tag's items (AND)
-				// results.retainAll(tie.items);
-
-				// union logic (OR) would be:
-				results.addAll(tie.items);
+				results.retainAll(tie.items);
 			}
 		}
 		if(results == null) {

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/TagIndex.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/indexing/TagIndex.java
@@ -64,58 +64,31 @@ public class TagIndex<T> {
 	}
 	
 	/**
-	 * Queries the tag index for items that match all or any of the tags listed in the tags parameter
-	 * depending on the presence of ':'.
-	 * @param tags colon/semicolon separated list of tag strings
+	 * Queries the tag index for items that match all of the tags listed in the tags parameter.
+	 * @param tags semicolon separated list of tag strings 
 	 * @return a set of items matching all the specified tags
 	 */
 	public Set<T> query(String tags) {
 		if(tags == null || tags.isEmpty()) {
 			return Collections.emptySet();
 		}
-		String lower = tags.toLowerCase();
+		String[] tagArray = tags.toLowerCase().split(";");
 		Set<T> results = null;
-		// If tags contains ':' use OR semantics, otherwise default to AND using ';'
-		if(lower.contains(":")) {
-			String[] tagArray = lower.split(":");
-			for(String tag : tagArray) {
-				tag = tag.trim();
-				if(tag.isEmpty()) continue;
-				TagIndexEntry tie = index.get(tag);
-				if(tie == null) {
-					// missing tag contributes nothing for OR
-					continue;
-				}
-				if(results == null) {
-					results = new THashSet<T>(tie.items);
-				} else {
-					results.addAll(tie.items);
-				}
-			}
-			if(results == null) {
+		for(String tag : tagArray) {
+			TagIndexEntry tie = index.get(tag);
+			if(tie == null) {
 				return Collections.emptySet();
 			}
-			return results;
-		} else {
-			String[] tagArray = lower.split(";");
-			for(String tag : tagArray) {
-				tag = tag.trim();
-				if(tag.isEmpty()) continue;
-				TagIndexEntry tie = index.get(tag);
-				if(tie == null) {
-					return Collections.emptySet();
-				}
-				if(results == null) {
-					results = new THashSet<T>(tie.items);
-				} else {
-					results.retainAll(tie.items);
-				}
-			}
 			if(results == null) {
-				return Collections.emptySet();
+				results = new THashSet<T>(tie.items);
+			} else {
+				results.retainAll(tie.items);
 			}
-			return results;
 		}
+		if(results == null) {
+			return Collections.emptySet();
+		}
+		return results;
 	}
 	
 	public Set<String> getTags() {

--- a/ols-geocoder-process/pom.xml
+++ b/ols-geocoder-process/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.bc.gov.ols</groupId>
     <artifactId>ols-geocoder</artifactId>
-    <version>4.5.2</version>
+    <version>4.5.2-private-road</version>
   </parent>
   <artifactId>ols-geocoder-process</artifactId>
   <name>OLS Geocoder Process</name>

--- a/ols-geocoder-process/pom.xml
+++ b/ols-geocoder-process/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.bc.gov.ols</groupId>
     <artifactId>ols-geocoder</artifactId>
-    <version>4.5.2-private-road</version>
+    <version>4.5.2</version>
   </parent>
   <artifactId>ols-geocoder-process</artifactId>
   <name>OLS Geocoder Process</name>

--- a/ols-geocoder-process/pom.xml
+++ b/ols-geocoder-process/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.bc.gov.ols</groupId>
     <artifactId>ols-geocoder</artifactId>
-    <version>4.5.2</version>
+    <version>4.5.3</version>
   </parent>
   <artifactId>ols-geocoder-process</artifactId>
   <name>OLS Geocoder Process</name>

--- a/ols-geocoder-process/src/main/java/ca/bc/gov/ols/siteloaderprep/RawStreetName.java
+++ b/ols-geocoder-process/src/main/java/ca/bc/gov/ols/siteloaderprep/RawStreetName.java
@@ -8,6 +8,7 @@ public class RawStreetName {
 	public String qual;
 	public boolean typeIsPrefix;
 	public boolean dirIsPrefix;
+	public boolean isPrivateRoad; // indicates if this street name is a private road name
 	
 	@Override
 	public String toString() {

--- a/ols-geocoder-process/src/main/java/ca/bc/gov/ols/streetprep/StreetPrep.java
+++ b/ols-geocoder-process/src/main/java/ca/bc/gov/ols/streetprep/StreetPrep.java
@@ -693,11 +693,19 @@ public class StreetPrep {
 				}
 			}
 			if("BCGNIS".equals(loc.source) && loc.containingLocalityId != null) {
-				RawLocalityMapping lm = new RawLocalityMapping();
-				lm.inputString = loc.name;
-				lm.localityId = loc.containingLocalityId;
-				lm.confidence = 80;
-				lmMap.put(lm.inputString + "|" + lm.localityId, lm);
+				// Existing: map to parent
+				RawLocalityMapping lmParent = new RawLocalityMapping();
+				lmParent.inputString = loc.name;
+				lmParent.localityId = loc.containingLocalityId;
+				lmParent.confidence = 80;
+				lmMap.put(lmParent.inputString + "|" + lmParent.localityId, lmParent);
+				
+				// NEW: map to self with higher confidence
+				RawLocalityMapping lmSelf = new RawLocalityMapping();
+				lmSelf.inputString = loc.name;
+				lmSelf.localityId = loc.id;               // Self!
+				lmSelf.confidence = 95;                    // Higher priority
+				lmMap.put(lmSelf.inputString + "|" + lmSelf.localityId, lmSelf);
 			}
 		}
 		return lmMap;

--- a/ols-geocoder-process/src/main/java/ca/bc/gov/ols/streetprep/StreetPrep.java
+++ b/ols-geocoder-process/src/main/java/ca/bc/gov/ols/streetprep/StreetPrep.java
@@ -693,19 +693,11 @@ public class StreetPrep {
 				}
 			}
 			if("BCGNIS".equals(loc.source) && loc.containingLocalityId != null) {
-				// Existing: map to parent
-				RawLocalityMapping lmParent = new RawLocalityMapping();
-				lmParent.inputString = loc.name;
-				lmParent.localityId = loc.containingLocalityId;
-				lmParent.confidence = 80;
-				lmMap.put(lmParent.inputString + "|" + lmParent.localityId, lmParent);
-				
-				// NEW: map to self with higher confidence
-				RawLocalityMapping lmSelf = new RawLocalityMapping();
-				lmSelf.inputString = loc.name;
-				lmSelf.localityId = loc.id;               // Self!
-				lmSelf.confidence = 95;                    // Higher priority
-				lmMap.put(lmSelf.inputString + "|" + lmSelf.localityId, lmSelf);
+				RawLocalityMapping lm = new RawLocalityMapping();
+				lm.inputString = loc.name;
+				lm.localityId = loc.containingLocalityId;
+				lm.confidence = 80;
+				lmMap.put(lm.inputString + "|" + lm.localityId, lm);
 			}
 		}
 		return lmMap;

--- a/ols-geocoder-web/pom.xml
+++ b/ols-geocoder-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2-private-road</version>
+		<version>4.5.2</version>
 	</parent>
 
 	<name>OLS Geocoder Web</name>

--- a/ols-geocoder-web/pom.xml
+++ b/ols-geocoder-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2</version>
+		<version>4.5.3</version>
 	</parent>
 
 	<name>OLS Geocoder Web</name>

--- a/ols-geocoder-web/pom.xml
+++ b/ols-geocoder-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>ca.bc.gov.ols</groupId>
 		<artifactId>ols-geocoder</artifactId>
-		<version>4.5.2</version>
+		<version>4.5.2-private-road</version>
 	</parent>
 
 	<name>OLS Geocoder Web</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>ca.bc.gov.ols</groupId>
 	<artifactId>ols-geocoder</artifactId>
-	<version>4.5.2</version>
+	<version>4.5.2-private-road</version>
 	<packaging>pom</packaging>
 	<name>OLS Geocoder</name>
 	<url>https://bcgov.github.io/ols-geocoder/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>ca.bc.gov.ols</groupId>
 	<artifactId>ols-geocoder</artifactId>
-	<version>4.5.2-private-road</version>
+	<version>4.5.2</version>
 	<packaging>pom</packaging>
 	<name>OLS Geocoder</name>
 	<url>https://bcgov.github.io/ols-geocoder/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>ca.bc.gov.ols</groupId>
 	<artifactId>ols-geocoder</artifactId>
-	<version>4.5.2</version>
+	<version>4.5.3</version>
 	<packaging>pom</packaging>
 	<name>OLS Geocoder</name>
 	<url>https://bcgov.github.io/ols-geocoder/</url>


### PR DESCRIPTION
1. Allow AND/OR logic in occupant tags search (default is now OR)
2. FuzzyMatch is now case insensitive
3. FuzzyMatch now prefer exact locality match over partial matches (Ganges now correctly maps to Ganges in Salt Spring Island)
4. Add WYN as a road type