### PR TITLE
LOC-7160: Proper handling of invalid siteUuid in ParcelController

### DIFF
--- a/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/controllers/ParcelController.java
+++ b/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/controllers/ParcelController.java
@@ -30,6 +30,7 @@ import ca.bc.gov.ols.geocoder.rest.OlsResponse;
 import ca.bc.gov.ols.geocoder.rest.PidsResponse;
 import ca.bc.gov.ols.geocoder.rest.converters.UuidParam;
 import ca.bc.gov.ols.geocoder.rest.exceptions.InvalidParameterException;
+import ca.bc.gov.ols.geocoder.rest.exceptions.NotFoundException;
 
 @RestController
 @RequestMapping("/parcels")
@@ -52,12 +53,10 @@ public class ParcelController {
 		
 		ISite site = geocoder.getDatastore().getRawSiteByUuid(siteUuid.getValue());
 		
-		PidsResponse pr;
 		if(site == null) {
-			pr = new PidsResponse(null, null);
+			throw new NotFoundException("No site found for the given UUID.");
 		}
-		
-		pr = new PidsResponse(site.getUuid(), site.getPids());
+		PidsResponse pr = new PidsResponse(site.getUuid(), site.getPids());
 		
 		OlsResponse response = new OlsResponse(pr);
 		response.setParams(params);

--- a/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/controllers/ParcelController.java
+++ b/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/controllers/ParcelController.java
@@ -30,7 +30,6 @@ import ca.bc.gov.ols.geocoder.rest.OlsResponse;
 import ca.bc.gov.ols.geocoder.rest.PidsResponse;
 import ca.bc.gov.ols.geocoder.rest.converters.UuidParam;
 import ca.bc.gov.ols.geocoder.rest.exceptions.InvalidParameterException;
-import ca.bc.gov.ols.geocoder.rest.exceptions.NotFoundException;
 
 @RestController
 @RequestMapping("/parcels")
@@ -53,12 +52,13 @@ public class ParcelController {
 		
 		ISite site = geocoder.getDatastore().getRawSiteByUuid(siteUuid.getValue());
 		
+		OlsResponse response;
 		if(site == null) {
-			throw new NotFoundException("No site found for the given UUID.");
+			response = new OlsResponse(null);
+		} else {
+			PidsResponse pr = new PidsResponse(site.getUuid(), site.getPids());
+			response = new OlsResponse(pr);
 		}
-		PidsResponse pr = new PidsResponse(site.getUuid(), site.getPids());
-		
-		OlsResponse response = new OlsResponse(pr);
 		response.setParams(params);
 		return response;
 	}


### PR DESCRIPTION
When calling `GET /parcels/pids/{siteUuid}` with a UUID that doesn't exist, the endpoint crashed with a 500 error.

[Jira ticket](https://dpdd.atlassian.net/browse/LOC-7160)

**Fix:** Return 404 with a clean error message instead, consistent with other endpoints.