### PR TITLE
LOC-7176: Fix NPE in intersections endpoint with invalid UUID

### DIFF
--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
@@ -1812,6 +1812,9 @@ return pids != null && !pids.trim().isEmpty();
 	
 	public StreetIntersectionAddress getIntersectionByUuid(UUID uuid) {
 		StreetIntersection intr = intersectionsByUuid.get(uuid);
+		if(intr == null) {
+			return null;
+		}
 		return new StreetIntersectionAddress(intr);
 	}
 	

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/TestDataSource.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/TestDataSource.java
@@ -81,7 +81,8 @@ public class TestDataSource implements GeocoderDataSource {
 	private TIntObjectHashMap<FlexObj> localities = new TIntObjectHashMap<FlexObj>();
 	private Map<String, Integer> localitySchema = FlexObj.createSchema(
 			new String[] {"locality_id", "locality_name", "locality_type_name",
-					"state_prov_terr_id", "geom", "locality_type_id", "electoral_area_id"});
+					"state_prov_terr_id", "geom", "locality_type_id", "electoral_area_id",
+					"locality_qualifier"});
 
 	private TIntObjectHashMap<FlexObj> electoralAreas = new TIntObjectHashMap<FlexObj>();
 	private Map<String, Integer> electoralAreaSchema = FlexObj.createSchema(
@@ -190,11 +191,11 @@ public class TestDataSource implements GeocoderDataSource {
 		// Localities IDs in 100-range
 		localities.put(101, new FlexObj(localitySchema,
 				new Object[] {101, "Victoria", "City", 10,
-						gf.createPoint(new Coordinate(1, 1)), 1, 1
+						gf.createPoint(new Coordinate(1, 1)), 1, 1, null
 				}));
 		localities.put(102, new FlexObj(localitySchema,
 				new Object[] {102, "Vancouver", "City", 10,
-						gf.createPoint(new Coordinate(1, 1)), 1, 2
+						gf.createPoint(new Coordinate(1, 1)), 1, 2, null
 				}));
 		
 		// Business Category IDs in the 200-range
@@ -222,11 +223,11 @@ public class TestDataSource implements GeocoderDataSource {
 		
 		// StreetNames IDs in 3000-range
 		streetNames.put(3001, new FlexObj(streetNameSchema,
-				new Object[] {3001, "Douglas", "St", null, null, null, "N", "N"}));
+				new Object[] {3001, "Douglas", "St", null, null, null, false, false}));
 		streetTypes.add("St");
 		
 		streetNameOnSegments.add(new FlexObj(streetNameOnSegmentSchema,
-				new Object[] {3001, 2001, "Y"}));
+				new Object[] {3001, 2001, true}));
 		
 		// StreetLocalityCentroids
 		streetLocalityCentroids.add(new FlexObj(streetLocalityCentroidSchema,
@@ -280,10 +281,10 @@ public class TestDataSource implements GeocoderDataSource {
 					"Software;Consulting;", "professionalScientificAndTechnicalServices",
 					LocalDate.of(2015,1,1), LocalDate.of(1979,1,1), "1", "1", ""
 				}));
-
 		combinedSitesPost.put(4002, new FlexObj(combinedSitesPostSchema,
 				new Object[] {4002, "00000000-0000-0000-0000-000000004002", null, null, null,
-						"parcelPoint", null, null, "medium", "A", LocalDate.of(2015,1,1), null, gf.createPoint(new Coordinate(1, 1)), "CAP", "Y", null, "medium", 4002, "A", null, null,
+						"parcelPoint", null, null, "medium", "A", LocalDate.of(2015,1,1), null, gf.createPoint(new Coordinate(1, 1)), "CAP", true, null,
+						"medium", 4002, "A", null, null,
 						gf.createPoint(new Coordinate(1, 1)), "Suite 419 – 1207 Douglas Street Victoria, British Columbia, Canada, V8W 2E7", 2001, 101, "028726014", "BCA"
 				}));
 

--- a/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/controllers/IntersectionController.java
+++ b/ols-geocoder-web/src/main/java/ca/bc/gov/ols/geocoder/rest/controllers/IntersectionController.java
@@ -59,7 +59,12 @@ public class IntersectionController {
 		
 		StreetIntersectionAddress addr = geocoder.getDatastore().getIntersectionByUuid(
 				uuid.getValue());
-		OlsResponse response = new OlsResponse(addr);
+		OlsResponse response;
+		if(addr == null) {
+			response = new OlsResponse(new StreetIntersectionAddress[0]);
+		} else {
+			response = new OlsResponse(addr);
+		}
 		response.setParams(params);
 		return response;
 	}

--- a/ols-geocoder-web/src/test/java/ca/bc/gov/ols/rest/controllers/IntersectionControllerTest.java
+++ b/ols-geocoder-web/src/test/java/ca/bc/gov/ols/rest/controllers/IntersectionControllerTest.java
@@ -1,0 +1,83 @@
+package ca.bc.gov.ols.rest.controllers;
+
+import ca.bc.gov.ols.geocoder.IGeocoder;
+import ca.bc.gov.ols.geocoder.GeocoderFactory;
+import ca.bc.gov.ols.geocoder.api.SharedParameters;
+import ca.bc.gov.ols.geocoder.api.data.StreetIntersectionAddress;
+import ca.bc.gov.ols.geocoder.rest.OlsResponse;
+import ca.bc.gov.ols.geocoder.rest.controllers.IntersectionController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.validation.BindingResult;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IntersectionControllerTest {
+	private static IGeocoder gc;
+
+	@Spy
+	SharedParameters queryParams;
+
+	@Spy
+	BindingResult bindingResult;
+
+	@InjectMocks
+	private IntersectionController ctrlr;
+
+	@BeforeEach
+	public void setup() throws Exception {
+		MockitoAnnotations.openMocks(this);
+		GeocoderFactory factory = new GeocoderFactory();
+		factory.setUnitTestMode("TRUE");
+		gc = factory.getGeocoder();
+		setPrivateField(ctrlr, "geocoder", gc);
+	}
+
+	@Tag("Prod")
+	@Test
+	public void testGetIntersectionByValidUuid() throws Exception {
+		OlsResponse resp = ctrlr.getIntersection(
+				"00000000-0000-0000-0000-000000001001", queryParams, bindingResult);
+		Object resp_o = resp.getResponseObj();
+		StreetIntersectionAddress addr = (resp_o instanceof StreetIntersectionAddress
+				? (StreetIntersectionAddress)resp_o : null);
+		assertNotNull(addr);
+		assertEquals("00000000-0000-0000-0000-000000001001", addr.getID());
+	}
+
+	@Tag("Prod")
+	@Test
+	public void testGetIntersectionByInvalidUuidDoesNotCrash() throws Exception {
+		OlsResponse resp = ctrlr.getIntersection(
+				"00000000-0000-0000-0000-000000009999", queryParams, bindingResult);
+		assertNotNull(resp);
+	}
+
+	@Tag("Prod")
+	@Test
+	public void testGetIntersectionByInvalidUuidReturnsEmpty() throws Exception {
+		OlsResponse resp = ctrlr.getIntersection(
+				"00000000-0000-0000-0000-000000009999", queryParams, bindingResult);
+		Object resp_o = resp.getResponseObj();
+		if(resp_o instanceof StreetIntersectionAddress[]) {
+			assertEquals(0, ((StreetIntersectionAddress[])resp_o).length);
+		} else {
+			assertNull(resp_o);
+		}
+	}
+
+	public static void setPrivateField(Object target, String fieldName, Object value){
+		try {
+			Field privateField = target.getClass().getDeclaredField(fieldName);
+			privateField.setAccessible(true);
+			privateField.set(target, value);
+		} catch(Exception e){
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
[Jira Ticket](https://dpdd.atlassian.net/browse/LOC-7176)

An invalid uuid in `GET /intersections/{id}` would respond with a 500 error. This fixes it to return a 200 with an empty response.