### PR TITLE
LOC-7157: Fix NPE on /sites/{id}/subsites for unknown UUID

### DIFF
--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/GeocoderDataStore.java
@@ -1711,11 +1711,15 @@ return pids != null && !pids.trim().isEmpty();
 			throw new FeatureNotSupportedException(GeocoderFeature.REVERSE_GEOCODE);
 		}
 		ISite parentSite = sitesByUuid.get(uuid);
-		if(parentSite.getPrimaryAccessPoint() == null) {
+		if(parentSite == null || parentSite.getPrimaryAccessPoint() == null) {
 			return new ArrayList<SiteAddress>(0);
 		}
-		ArrayList<SiteAddress> sites = new ArrayList<SiteAddress>(parentSite.getChildren().size());
-		for(ISite site : parentSite.getChildren()) {
+		List<ISite> children = parentSite.getChildren();
+		if(children == null) {
+			return new ArrayList<SiteAddress>(0);
+		}
+		ArrayList<SiteAddress> sites = new ArrayList<SiteAddress>(children.size());
+		for(ISite site : children) {
 			SiteAddress address = new SiteAddress(site, null);
 			loadSiteDetailsById(address, site, site.getPrimaryAccessPoint());
 			address.resolveLocation(this, site, ld, setBack);

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/AbstractSite.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/data/AbstractSite.java
@@ -133,6 +133,9 @@ public abstract class AbstractSite extends LocationBase implements ISite {
 
 	@Override
 	public List<ISite> getChildren() {
+		if(children == null) {
+			return Collections.emptyList();
+		}
 		return Collections.unmodifiableList(children);
 	}
 	

--- a/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/TestDataSource.java
+++ b/ols-geocoder-core/src/main/java/ca/bc/gov/ols/geocoder/datasources/TestDataSource.java
@@ -81,7 +81,8 @@ public class TestDataSource implements GeocoderDataSource {
 	private TIntObjectHashMap<FlexObj> localities = new TIntObjectHashMap<FlexObj>();
 	private Map<String, Integer> localitySchema = FlexObj.createSchema(
 			new String[] {"locality_id", "locality_name", "locality_type_name",
-					"state_prov_terr_id", "geom", "locality_type_id", "electoral_area_id"});
+					"state_prov_terr_id", "geom", "locality_type_id", "electoral_area_id",
+					"locality_qualifier"});
 
 	private TIntObjectHashMap<FlexObj> electoralAreas = new TIntObjectHashMap<FlexObj>();
 	private Map<String, Integer> electoralAreaSchema = FlexObj.createSchema(
@@ -190,11 +191,11 @@ public class TestDataSource implements GeocoderDataSource {
 		// Localities IDs in 100-range
 		localities.put(101, new FlexObj(localitySchema,
 				new Object[] {101, "Victoria", "City", 10,
-						gf.createPoint(new Coordinate(1, 1)), 1, 1
+						gf.createPoint(new Coordinate(1, 1)), 1, 1, null
 				}));
 		localities.put(102, new FlexObj(localitySchema,
 				new Object[] {102, "Vancouver", "City", 10,
-						gf.createPoint(new Coordinate(1, 1)), 1, 2
+						gf.createPoint(new Coordinate(1, 1)), 1, 2, null
 				}));
 		
 		// Business Category IDs in the 200-range
@@ -222,11 +223,11 @@ public class TestDataSource implements GeocoderDataSource {
 		
 		// StreetNames IDs in 3000-range
 		streetNames.put(3001, new FlexObj(streetNameSchema,
-				new Object[] {3001, "Douglas", "St", null, null, null, "N", "N"}));
+				new Object[] {3001, "Douglas", "St", null, null, null, false, false}));
 		streetTypes.add("St");
 		
 		streetNameOnSegments.add(new FlexObj(streetNameOnSegmentSchema,
-				new Object[] {3001, 2001, "Y"}));
+				new Object[] {3001, 2001, true}));
 		
 		// StreetLocalityCentroids
 		streetLocalityCentroids.add(new FlexObj(streetLocalityCentroidSchema,
@@ -260,13 +261,13 @@ public class TestDataSource implements GeocoderDataSource {
 		// AccessPoints IDs in 5000-range
 		accessPoints.put(5001, new FlexObj(accessPointSchema,
 				new Object[] {5001, "NCAP", 1, 4001,
-						2001, 101, null, null, "medium", "Y",
+						2001, 101, null, null, "medium", true,
 						gf.createPoint(new Coordinate(1, 1))
 				}));
 
 		accessPoints.put(5002, new FlexObj(accessPointSchema,
 				new Object[] {5002, "CAP", 1, 4002,
-						2001, 101, 1207, null, "medium", "Y",
+						2001, 101, 1207, null, "medium", true,
 						gf.createPoint(new Coordinate(2, 2))
 				}));
 		
@@ -283,8 +284,14 @@ public class TestDataSource implements GeocoderDataSource {
 
 		combinedSitesPost.put(4002, new FlexObj(combinedSitesPostSchema,
 				new Object[] {4002, "00000000-0000-0000-0000-000000004002", null, null, null,
-						"parcelPoint", null, null, "medium", "A", LocalDate.of(2015,1,1), null, gf.createPoint(new Coordinate(1, 1)), "CAP", "Y", null, "medium", 4002, "A", null, null,
+						"parcelPoint", null, null, "medium", "A", LocalDate.of(2015,1,1), null, gf.createPoint(new Coordinate(1, 1)), "CAP", true, null, "medium", 4002, "A", null, null,
 						gf.createPoint(new Coordinate(1, 1)), "Suite 419 – 1207 Douglas Street Victoria, British Columbia, Canada, V8W 2E7", 2001, 101, "028726014", "BCA"
+				}));
+
+		combinedSitesPost.put(4003, new FlexObj(combinedSitesPostSchema,
+				new Object[] {4003, "00000000-0000-0000-0000-000000004003", 4002, null, null,
+						null, "419", null, "medium", "A", LocalDate.of(2015,1,1), null, gf.createPoint(new Coordinate(2, 2)), "NCAP", true, null, "medium", null, null, "A", null,
+						gf.createPoint(new Coordinate(2, 2)), "Suite 419 Sayward Building", 2001, 101, "028726015", "419"
 				}));
 
 		streetSegmentsPost.put(2001, new FlexObj(streetSegmentsPostSchema,

--- a/ols-geocoder-web/src/test/java/ca/bc/gov/ols/rest/controllers/SiteControllerTest.java
+++ b/ols-geocoder-web/src/test/java/ca/bc/gov/ols/rest/controllers/SiteControllerTest.java
@@ -1,0 +1,96 @@
+package ca.bc.gov.ols.rest.controllers;
+
+import ca.bc.gov.ols.geocoder.IGeocoder;
+import ca.bc.gov.ols.geocoder.GeocoderFactory;
+import ca.bc.gov.ols.geocoder.api.SharedParameters;
+import ca.bc.gov.ols.geocoder.api.data.SiteAddress;
+import ca.bc.gov.ols.geocoder.rest.OlsResponse;
+import ca.bc.gov.ols.geocoder.rest.controllers.SiteController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.springframework.validation.BindingResult;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SiteControllerTest {
+	private static IGeocoder gc;
+
+	@Spy
+	SharedParameters queryParams;
+
+	@Spy
+	BindingResult bindingResult;
+
+	@InjectMocks
+	private SiteController ctrlr;
+
+	@BeforeEach
+	public void setup() throws Exception {
+		MockitoAnnotations.openMocks(this);
+		GeocoderFactory factory = new GeocoderFactory();
+		factory.setUnitTestMode("TRUE");
+		gc = factory.getGeocoder();
+		setPrivateField(ctrlr, "geocoder", gc);
+	}
+
+	@Tag("Prod")
+	@Test
+	public void testGetSubSitesByValidUuidWithChildren() throws Exception {
+		OlsResponse resp = ctrlr.getSubSites(
+				"00000000-0000-0000-0000-000000004002", queryParams, bindingResult);
+		Object resp_o = resp.getResponseObj();
+		SiteAddress[] addrs = (resp_o instanceof SiteAddress[]
+				? (SiteAddress[])resp_o : null);
+		assertNotNull(addrs);
+		assertEquals(1, addrs.length);
+		assertEquals("UNIT 419, parcelPoint -- Douglas St, Victoria, BC", addrs[0].getAddressString());
+	}
+
+	@Tag("Prod")
+	@Test
+	public void testGetSubSitesByValidUuidNoChildren() throws Exception {
+		OlsResponse resp = ctrlr.getSubSites(
+				"00000000-0000-0000-0000-000000004001", queryParams, bindingResult);
+		Object resp_o = resp.getResponseObj();
+		SiteAddress[] addrs = (resp_o instanceof SiteAddress[]
+				? (SiteAddress[])resp_o : null);
+		assertNotNull(addrs);
+		assertEquals(0, addrs.length);
+	}
+
+	@Tag("Prod")
+	@Test
+	public void testGetSubSitesByInvalidUuidDoesNotCrash() throws Exception {
+		OlsResponse resp = ctrlr.getSubSites(
+				"00000000-0000-0000-0000-000000009999", queryParams, bindingResult);
+		assertNotNull(resp);
+	}
+
+	@Tag("Prod")
+	@Test
+	public void testGetSubSitesByInvalidUuidReturnsEmpty() throws Exception {
+		OlsResponse resp = ctrlr.getSubSites(
+				"00000000-0000-0000-0000-000000009999", queryParams, bindingResult);
+		Object resp_o = resp.getResponseObj();
+		if(resp_o instanceof SiteAddress[]) {
+			assertEquals(0, ((SiteAddress[])resp_o).length);
+		} else {
+			assertNull(resp_o);
+		}
+	}
+
+	public static void setPrivateField(Object target, String fieldName, Object value){
+		try {
+			Field privateField = target.getClass().getDeclaredField(fieldName);
+			privateField.setAccessible(true);
+			privateField.set(target, value);
+		} catch(Exception e){
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
An invalid uuid in GET /sites/{id}/subsites would respond with a 500 error. This fixes it to return a 200 with an empty response.